### PR TITLE
Add WOOP Success Course React app, Vite scaffold, and facilitator guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-nike_social_media_analysis_2025.csv
-nike_dashboard.html
-__pycache__/
+web/node_modules/
+web/dist/

--- a/README.md
+++ b/README.md
@@ -1,14 +1,37 @@
 # tutor_app
 
-This repository contains a Python script that analyzes Nike's 2025 social media metrics.
+This repository now contains:
 
-## Requirements
+- A React single-file WOOP web app for Success-course facilitation (`web/src/WOOPSuccessApp.jsx`).
+- A mini-textbook + Notion mapping guide (`docs/woop_success_course_guide.md`).
+- The original Nike social media analysis script (`nike_social_media_analysis.py`).
+
+## WOOP web app (single-file component)
+
+Drop `web/src/WOOPSuccessApp.jsx` into a Vite/Next React project and render it from your app entry point.
+
+### What the app includes
+
+- Guided WOOP sequence: Wish → Outcome → Obstacle → Plan.
+- Visualization timers for Outcome/Obstacle imagery pauses.
+- Internal-obstacle prompting and observable When–Then planning.
+- Success-course reflection prompts (12-month success/failure + meaning/feelings).
+- Facilitation script panel + preloaded examples.
+- Notion markdown export and printable WOOP card.
+
+## Notion implementation
+
+Follow `docs/woop_success_course_guide.md` to create a matching Notion database and templates.
+
+## Original Nike analysis script
+
+### Requirements
 
 - Python 3
 - pandas
 - plotly
 
-## Usage
+### Usage
 
 Install dependencies:
 
@@ -22,8 +45,7 @@ Run the analysis:
 python nike_social_media_analysis.py
 ```
 
-The script prints a console report and generates two files:
+The script prints a console report and generates:
 
 - `nike_social_media_analysis_2025.csv`
 - `nike_dashboard.html`
-

--- a/docs/woop_success_course_guide.md
+++ b/docs/woop_success_course_guide.md
@@ -1,0 +1,70 @@
+# WOOP Success Course Mini-Textbook + Notion Workflow
+
+## 1) App blueprint (UX + pedagogy)
+
+This app is a **10-minute guided WOOP activity** for a Success course:
+
+1. **Wish**: select a challenging but feasible goal.
+2. **Outcome**: name the best result and how it feels.
+3. **Obstacle**: identify an internal obstacle (habit, belief, emotion, impulse).
+4. **Plan**: write a concrete **When–Then** response.
+5. **Success reflection**: connect WOOP to 12-month success/failure stories.
+6. **Export**: copy Notion markdown, print a WOOP card, or keep JSON/state locally.
+
+Core implementation rule: preserve the sequence and exact structure because WOOP effects rely on the order.
+
+## 2) Concepts explained
+
+### Mental contrasting
+Positive fantasy alone can reduce effort. WOOP instead contrasts:
+- the desired future (Outcome), and
+- current internal reality (Obstacle).
+
+That contrast supports goal commitment and energizes action.
+
+### Implementation intentions (When–Then)
+A WOOP plan is not “I’ll try harder.”
+
+It is:
+- **When** cue X happens (obstacle cue),
+- **Then** I perform action Y (observable behavior).
+
+This cue-response pairing supports more automatic execution when the obstacle appears.
+
+## 3) Success-course objective mapping
+
+| WOOP Step | Prompt | Course alignment |
+|---|---|---|
+| Wish | “What do you want to accomplish in 7–30 days?” | Defines success behaviorally |
+| Outcome | “What changes and how will success feel?” | Links success to emotion and meaning |
+| Obstacle | “What inside you causes failure loops?” | Reframes failure as a modifiable pattern |
+| Plan | “When X, then I will Y.” | Converts reflection into repeatable action |
+| Debrief | “How do last-year success/failure stories map to obstacle patterns?” | Builds reflective self-awareness |
+
+## 4) Notion structure
+
+Create a Notion database named **WOOP (Success Course)** with properties:
+
+- Wish (Title)
+- Outcome (Text)
+- Obstacle (Text)
+- Plan When (Text)
+- Plan Then (Text)
+- 12mo Success (Text)
+- 12mo Failure (Text)
+- Meaning of Success (Text)
+- Feels: Success (Text)
+- Feels: Failure (Text)
+- Classmates Notes (Text)
+- Check-in Date (Date)
+- Status (Select: Draft / Active / Completed)
+- Review Result (Select: Worked / Partly / Didn’t)
+
+Page template guidance: paste the markdown exported from the app’s **Copy for Notion** button.
+
+## 5) Facilitator-use recommendations
+
+- Model one full WOOP first.
+- Keep obstacle language internal and controllable.
+- Enforce observable Then-actions.
+- Set a check-in date to promote WOOP repetition and habit formation.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WOOP Success Course App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,1043 @@
+{
+  "name": "woop-success-app",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "woop-success-app",
+      "version": "0.0.1",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "vite": "^5.4.14"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "woop-success-app",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "vite": "^5.4.14"
+  }
+}

--- a/web/src/WOOPSuccessApp.jsx
+++ b/web/src/WOOPSuccessApp.jsx
@@ -1,0 +1,643 @@
+import React, { useMemo, useState, useEffect } from "react";
+
+/**
+ * WOOP for Classrooms (Character Lab) + Success Course Extension
+ *
+ * Notes grounded in Character Lab:
+ * - Keep sequence + language consistent (Wish → Outcome → Obstacle → Plan + imagery pauses).
+ * - Obstacle must be INTERNAL (under your control).
+ * - Plan is a When–Then (implementation intention), with an observable action.
+ */
+
+const DEFAULTS = {
+  wish: "",
+  outcome: "",
+  obstacle: "",
+  planWhen: "",
+  planThen: "",
+  // Success-course add-on
+  last12moSuccess: "",
+  last12moFailure: "",
+  meaningSuccess: "",
+  feltSuccess: "",
+  feltFailure: "",
+  peersNotes: "",
+  checkInDate: "",
+};
+
+const EXAMPLES = [
+  {
+    title: "Student Example (Biology Quiz)",
+    wish: "Get an A on my biology quiz",
+    outcome: "I’ll feel proud.",
+    obstacle: "I procrastinate.",
+    planWhen: "I finish dinner",
+    planThen: "Make 5 flash cards",
+  },
+  {
+    title: "Teacher Example (Grading)",
+    wish: "Grade all unit exams before Monday",
+    outcome: "Less stress; kids get feedback",
+    obstacle: "Write too much feedback",
+    planWhen: "I grade exams",
+    planThen: "Time myself for 4 min per exam",
+  },
+];
+
+function Timer({ seconds = 20, label }) {
+  const [left, setLeft] = useState(seconds);
+  const [running, setRunning] = useState(false);
+  const done = left === 0;
+
+  useEffect(() => {
+    if (!running) return undefined;
+    if (left <= 0) return undefined;
+    const t = setInterval(() => setLeft((x) => x - 1), 1000);
+    return () => clearInterval(t);
+  }, [running, left]);
+
+  const reset = () => {
+    setRunning(false);
+    setLeft(seconds);
+  };
+
+  return (
+    <div style={styles.timerBox}>
+      <div style={{ fontWeight: 700, marginBottom: 6 }}>Visualization Pause</div>
+      <div style={{ opacity: 0.85, marginBottom: 10 }}>{label}</div>
+      <div style={styles.timerRow}>
+        <div style={styles.time}>{`0:${String(left).padStart(2, "0")}`}</div>
+        <button style={styles.btn} onClick={() => setRunning((r) => !r)}>
+          {running ? "Pause" : "Start"}
+        </button>
+        <button style={styles.btnGhost} onClick={reset}>
+          Reset
+        </button>
+      </div>
+      {done && (
+        <div style={{ color: "#0a7a2f", marginTop: 8, fontWeight: 600 }}>
+          Done. Write what you noticed.
+        </div>
+      )}
+    </div>
+  );
+}
+
+const STEPS = [
+  { id: "intro", title: "Welcome" },
+  { id: "wish", title: "Wish" },
+  { id: "outcome", title: "Outcome" },
+  { id: "obstacle", title: "Obstacle" },
+  { id: "plan", title: "Plan" },
+  { id: "success", title: "Success Reflection" },
+  { id: "wrap", title: "WOOP Card + Notion Export" },
+];
+
+export default function WOOPSuccessApp() {
+  const [step, setStep] = useState(0);
+  const [data, setData] = useState(DEFAULTS);
+  const [showFacilitator, setShowFacilitator] = useState(false);
+  const [showExamples, setShowExamples] = useState(false);
+
+  const current = STEPS[step];
+
+  const canNext = useMemo(() => {
+    const s = current.id;
+    if (s === "wish") return data.wish.trim().length > 0;
+    if (s === "outcome") return data.outcome.trim().length > 0;
+    if (s === "obstacle") return data.obstacle.trim().length > 0;
+    if (s === "plan") return data.planWhen.trim().length > 0 && data.planThen.trim().length > 0;
+    return true;
+  }, [current.id, data]);
+
+  const update = (k, v) => setData((d) => ({ ...d, [k]: v }));
+
+  const loadExample = (ex) => {
+    setData((d) => ({
+      ...d,
+      wish: ex.wish,
+      outcome: ex.outcome,
+      obstacle: ex.obstacle,
+      planWhen: ex.planWhen,
+      planThen: ex.planThen,
+    }));
+    setStep(1);
+    setShowExamples(false);
+  };
+
+  const notionExport = useMemo(() => {
+    return `# WOOP (Success Course)
+
+## WISH
+${data.wish || "…"}
+
+## OUTCOME (best result + how I feel)
+${data.outcome || "…"}
+
+## OBSTACLE (internal)
+${data.obstacle || "…"}
+
+## PLAN (When–Then)
+**When:** ${data.planWhen || "…"}  
+**Then I will:** ${data.planThen || "…"}
+
+---
+
+# Success & Failure Reflection (last 12 months)
+
+## One Success
+${data.last12moSuccess || "…"}
+
+## One Failure
+${data.last12moFailure || "…"}
+
+## What does success mean to me?
+${data.meaningSuccess || "…"}
+
+## How does success feel?
+${data.feltSuccess || "…"}
+
+## How does failure feel?
+${data.feltFailure || "…"}
+
+## Notes on classmates’ ideas (patterns / differences)
+${data.peersNotes || "…"}
+
+## Check-in date (to make WOOP a habit)
+${data.checkInDate || "…"}
+`;
+  }, [data]);
+
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(notionExport);
+    window.alert("Copied. Paste into Notion.");
+  };
+
+  const resetAll = () => {
+    setData(DEFAULTS);
+    setStep(0);
+  };
+
+  return (
+    <div style={styles.page}>
+      <header style={styles.header}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <div style={styles.logo}>WOOP</div>
+          <div>
+            <div style={{ fontWeight: 800 }}>WOOP for Success Course</div>
+            <div style={{ opacity: 0.7, fontSize: 12 }}>10 minutes · Self-Control + Reflection</div>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap", justifyContent: "flex-end" }}>
+          <button style={styles.btnGhost} onClick={() => setShowExamples((x) => !x)}>
+            {showExamples ? "Hide Examples" : "Show Examples"}
+          </button>
+          <button style={styles.btnGhost} onClick={() => setShowFacilitator((x) => !x)}>
+            {showFacilitator ? "Hide Facilitator Script" : "Facilitator Script"}
+          </button>
+        </div>
+      </header>
+
+      {showFacilitator && (
+        <div style={styles.panel}>
+          <div style={{ fontWeight: 800, marginBottom: 6 }}>Facilitator Script (Character Lab style)</div>
+          <div style={{ lineHeight: 1.4, opacity: 0.9 }}>
+            “WOOP is a strategy that will help you gain insight into your daily life and fulfill your wishes.
+            Relax while I guide you through WOOP. The next few minutes are just for you.”
+            <br />
+            “WISH: Write a wish that is important to you. The wish should be difficult but achievable. State it
+            briefly.”
+            <br />
+            “OUTCOME: How will it feel when you accomplish this? Close your eyes and really imagine it.”
+            <br />
+            “OBSTACLE: What is an internal obstacle? This must be something you have control over. Close your
+            eyes and imagine your obstacle.”
+            <br />
+            “PLAN: What is your specific plan? What is the exact thing you will do? This plan should be easy to
+            remember.”
+            <br />
+            “We’ll check in again. WOOP is most helpful when it becomes a habit.”
+            <br />
+          </div>
+        </div>
+      )}
+
+      {showExamples && (
+        <div style={styles.panel}>
+          <div style={{ fontWeight: 800, marginBottom: 10 }}>Examples (tap to load)</div>
+          <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
+            {EXAMPLES.map((ex) => (
+              <button key={ex.title} style={styles.cardBtn} onClick={() => loadExample(ex)}>
+                <div style={{ fontWeight: 800, marginBottom: 6 }}>{ex.title}</div>
+                <div style={styles.small}>
+                  <b>W:</b> {ex.wish}
+                </div>
+                <div style={styles.small}>
+                  <b>O:</b> {ex.outcome}
+                </div>
+                <div style={styles.small}>
+                  <b>O:</b> {ex.obstacle}
+                </div>
+                <div style={styles.small}>
+                  <b>P:</b> When {ex.planWhen}, then I will {ex.planThen}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <main style={styles.main}>
+        <StepBar step={step} />
+
+        <div style={styles.content}>
+          {current.id === "intro" && (
+            <div>
+              <h1 style={styles.h1}>What is WOOP?</h1>
+              <p style={styles.p}>
+                WOOP is a practical, evidence-based activity that helps you fulfill wishes by building self-control.
+                It stands for <b>Wish</b>, <b>Outcome</b>, <b>Obstacle</b>, <b>Plan</b>.
+              </p>
+
+              <div style={styles.grid2}>
+                <div style={styles.box}>
+                  <div style={styles.boxTitle}>How it works</div>
+                  <div style={styles.p}>
+                    WOOP avoids a common goal-setting mistake: fantasizing about success without considering
+                    what holds you back. You’ll contrast your desired future with an internal obstacle, then create a
+                    When–Then plan.
+                  </div>
+                </div>
+                <div style={styles.box}>
+                  <div style={styles.boxTitle}>Success course tie-in</div>
+                  <div style={styles.p}>
+                    This is not just “set a goal.” You’ll connect success/failure to lived experience: what you count
+                    as success, what failure feels like, and how your obstacles shape the story.
+                  </div>
+                </div>
+              </div>
+
+              <button style={styles.primary} onClick={() => setStep(1)}>
+                Start WOOP
+              </button>
+            </div>
+          )}
+
+          {current.id === "wish" && (
+            <div>
+              <h1 style={styles.h1}>WISH</h1>
+              <p style={styles.p}>
+                Write a wish that is <b>important</b>, <b>challenging but feasible</b>, and can fit a timeframe
+                (today/this week/this month).
+              </p>
+              <Field
+                label="My wish"
+                value={data.wish}
+                onChange={(v) => update("wish", v)}
+                placeholder="e.g., Finish my Success course reflection by Friday"
+              />
+              <Hint>Keep it short. One sentence.</Hint>
+            </div>
+          )}
+
+          {current.id === "outcome" && (
+            <div>
+              <h1 style={styles.h1}>OUTCOME</h1>
+              <p style={styles.p}>What is the best result of achieving your wish? How will you feel?</p>
+              <FieldArea
+                label="Best outcome + feelings"
+                value={data.outcome}
+                onChange={(v) => update("outcome", v)}
+                placeholder="e.g., I’ll feel calmer, proud, and less haunted by unfinished work"
+              />
+              <Timer
+                seconds={20}
+                label="Close your eyes and really imagine the outcome vividly (scene, body, emotions)."
+              />
+            </div>
+          )}
+
+          {current.id === "obstacle" && (
+            <div>
+              <h1 style={styles.h1}>OBSTACLE (internal)</h1>
+              <p style={styles.p}>
+                This must be something <b>inside you</b> that you have control over (emotion, habit, belief), not an
+                external barrier.
+              </p>
+              <FieldArea
+                label="My main internal obstacle"
+                value={data.obstacle}
+                onChange={(v) => update("obstacle", v)}
+                placeholder="e.g., I spiral into overthinking and avoid starting"
+              />
+              <Timer
+                seconds={20}
+                label="Close your eyes and imagine the obstacle happening. Where are you? What do you do?"
+              />
+            </div>
+          )}
+
+          {current.id === "plan" && (
+            <div>
+              <h1 style={styles.h1}>PLAN (When–Then)</h1>
+              <p style={styles.p}>
+                Create a plan that links the obstacle cue to an <b>observable action</b>. Not “be disciplined.” A
+                real behavior.
+              </p>
+
+              <Field
+                label="When (the obstacle occurs)"
+                value={data.planWhen}
+                onChange={(v) => update("planWhen", v)}
+                placeholder="e.g., I open Instagram while studying"
+              />
+              <Field
+                label="Then I will (one specific action)"
+                value={data.planThen}
+                onChange={(v) => update("planThen", v)}
+                placeholder="e.g., put my phone in another room and do 5 minutes of reading"
+              />
+              <Hint>Quality check: could someone watching you tell you did it?</Hint>
+            </div>
+          )}
+
+          {current.id === "success" && (
+            <div>
+              <h1 style={styles.h1}>Success & Failure Reflection (last 12 months)</h1>
+              <p style={styles.p}>
+                Now we connect WOOP to your Success course objective: awareness of your personal definitions of
+                success/failure.
+              </p>
+
+              <FieldArea
+                label="One success in the last 12 months"
+                value={data.last12moSuccess}
+                onChange={(v) => update("last12moSuccess", v)}
+                placeholder="What happened? Why do you count it as success?"
+              />
+              <FieldArea
+                label="One failure in the last 12 months"
+                value={data.last12moFailure}
+                onChange={(v) => update("last12moFailure", v)}
+                placeholder="What happened? What belief did it trigger about you?"
+              />
+              <FieldArea
+                label="What does it mean to be successful?"
+                value={data.meaningSuccess}
+                onChange={(v) => update("meaningSuccess", v)}
+                placeholder="Your definition, not Instagram’s"
+              />
+              <FieldArea
+                label="How does success feel in your body?"
+                value={data.feltSuccess}
+                onChange={(v) => update("feltSuccess", v)}
+              />
+              <FieldArea
+                label="How does failure feel in your body?"
+                value={data.feltFailure}
+                onChange={(v) => update("feltFailure", v)}
+              />
+
+              <FieldArea
+                label="Notes on classmates’ ideas (patterns/differences)"
+                value={data.peersNotes}
+                onChange={(v) => update("peersNotes", v)}
+                placeholder="What do other people call success? What do you disagree with?"
+              />
+
+              <Field
+                label="Check-in date (WOOP works best as a habit)"
+                value={data.checkInDate}
+                onChange={(v) => update("checkInDate", v)}
+                placeholder="e.g., 2026-02-23"
+              />
+            </div>
+          )}
+
+          {current.id === "wrap" && (
+            <div>
+              <h1 style={styles.h1}>Your WOOP Card</h1>
+              <div style={styles.woopCard}>
+                <div style={styles.cardRow}>
+                  <b>WISH:</b> {data.wish || "…"}{" "}
+                </div>
+                <div style={styles.cardRow}>
+                  <b>OUTCOME:</b> {data.outcome || "…"}{" "}
+                </div>
+                <div style={styles.cardRow}>
+                  <b>OBSTACLE:</b> {data.obstacle || "…"}{" "}
+                </div>
+                <div style={styles.cardRow}>
+                  <b>PLAN:</b> <br />
+                  <b>When</b> {data.planWhen || "…"}, <b>then I will</b> {data.planThen || "…"}
+                </div>
+              </div>
+
+              <div style={styles.row}>
+                <button style={styles.primary} onClick={copyToClipboard}>
+                  Copy for Notion
+                </button>
+                <button style={styles.btnGhost} onClick={() => window.print()}>
+                  Print
+                </button>
+                <button style={styles.btnGhost} onClick={resetAll}>
+                  Start New
+                </button>
+              </div>
+
+              <div style={styles.box}>
+                <div style={styles.boxTitle}>Notion Export Preview</div>
+                <pre style={styles.pre}>{notionExport}</pre>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <Nav step={step} setStep={setStep} canNext={canNext} />
+      </main>
+
+      <footer style={styles.footer}>
+        Based on the WOOP strategy developed by Gabriele Oettingen & Peter M. Gollwitzer; classroom materials by
+        Character Lab.
+      </footer>
+    </div>
+  );
+}
+
+function StepBar({ step }) {
+  return (
+    <div style={styles.stepBar}>
+      {STEPS.map((s, i) => (
+        <div key={s.id} style={{ ...styles.step, ...(i === step ? styles.stepActive : i < step ? styles.stepDone : {}) }}>
+          {i + 1}. {s.title}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Nav({ step, setStep, canNext }) {
+  return (
+    <div style={styles.nav}>
+      <button style={styles.btnGhost} onClick={() => setStep((x) => Math.max(0, x - 1))} disabled={step === 0}>
+        Back
+      </button>
+      <button
+        style={{ ...styles.primary, opacity: canNext ? 1 : 0.4 }}
+        onClick={() => canNext && setStep((x) => Math.min(STEPS.length - 1, x + 1))}
+      >
+        {step === STEPS.length - 1 ? "Done" : "Next"}
+      </button>
+    </div>
+  );
+}
+
+function Field({ label, value, onChange, placeholder }) {
+  return (
+    <div style={styles.field}>
+      <div style={styles.label}>{label}</div>
+      <input style={styles.input} value={value} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}
+
+function FieldArea({ label, value, onChange, placeholder }) {
+  return (
+    <div style={styles.field}>
+      <div style={styles.label}>{label}</div>
+      <textarea style={styles.textarea} value={value} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}
+
+function Hint({ children }) {
+  return <div style={styles.hint}>{children}</div>;
+}
+
+const styles = {
+  page: {
+    fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, Arial",
+    background: "#f6f7fb",
+    minHeight: "100vh",
+  },
+  header: {
+    position: "sticky",
+    top: 0,
+    background: "white",
+    borderBottom: "1px solid #e5e7eb",
+    padding: "14px 18px",
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    zIndex: 20,
+  },
+  logo: {
+    background: "#4f46e5",
+    color: "white",
+    fontWeight: 900,
+    borderRadius: 10,
+    padding: "8px 10px",
+    letterSpacing: 1,
+  },
+  main: { maxWidth: 980, margin: "0 auto", padding: 18, display: "grid", gap: 14 },
+  panel: {
+    maxWidth: 980,
+    margin: "12px auto 0",
+    padding: 14,
+    background: "#eef2ff",
+    border: "1px solid #c7d2fe",
+    borderRadius: 14,
+  },
+  stepBar: { display: "flex", gap: 8, flexWrap: "wrap" },
+  step: {
+    fontSize: 12,
+    padding: "8px 10px",
+    borderRadius: 999,
+    border: "1px solid #e5e7eb",
+    background: "white",
+    opacity: 0.75,
+  },
+  stepActive: { background: "#111827", color: "white", opacity: 1, borderColor: "#111827" },
+  stepDone: { background: "#d1fae5", borderColor: "#6ee7b7", opacity: 1 },
+  content: { background: "white", border: "1px solid #e5e7eb", borderRadius: 18, padding: 18 },
+  h1: { margin: "4px 0 6px", fontSize: 28, letterSpacing: -0.2 },
+  p: { margin: "0 0 14px", opacity: 0.85, lineHeight: 1.5 },
+  field: { marginBottom: 12 },
+  label: { fontWeight: 800, marginBottom: 6 },
+  input: { width: "100%", padding: "12px 12px", borderRadius: 12, border: "1px solid #d1d5db", fontSize: 15 },
+  textarea: {
+    width: "100%",
+    padding: "12px 12px",
+    borderRadius: 12,
+    border: "1px solid #d1d5db",
+    minHeight: 110,
+    fontSize: 15,
+  },
+  hint: { fontSize: 13, opacity: 0.7, marginTop: 6 },
+  nav: { display: "flex", justifyContent: "space-between", gap: 10 },
+  btn: {
+    padding: "10px 12px",
+    borderRadius: 12,
+    border: "1px solid #2563eb",
+    background: "#2563eb",
+    color: "white",
+    fontWeight: 800,
+    cursor: "pointer",
+  },
+  btnGhost: {
+    padding: "10px 12px",
+    borderRadius: 12,
+    border: "1px solid #d1d5db",
+    background: "white",
+    fontWeight: 800,
+    cursor: "pointer",
+  },
+  primary: {
+    padding: "10px 14px",
+    borderRadius: 12,
+    border: "1px solid #4f46e5",
+    background: "#4f46e5",
+    color: "white",
+    fontWeight: 900,
+    cursor: "pointer",
+  },
+  grid2: {
+    display: "grid",
+    gap: 12,
+    gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+    marginBottom: 12,
+  },
+  box: { padding: 14, background: "#f9fafb", border: "1px solid #e5e7eb", borderRadius: 14 },
+  boxTitle: { fontWeight: 900, marginBottom: 6 },
+  timerBox: {
+    marginTop: 12,
+    padding: 14,
+    borderRadius: 14,
+    border: "1px solid #bfdbfe",
+    background: "#eff6ff",
+  },
+  timerRow: { display: "flex", gap: 10, alignItems: "center" },
+  time: { fontSize: 22, fontWeight: 900, width: 78, textAlign: "center" },
+  woopCard: { border: "2px solid #111827", borderRadius: 16, padding: 14, background: "#fff" },
+  cardRow: { marginBottom: 8, lineHeight: 1.4 },
+  pre: {
+    whiteSpace: "pre-wrap",
+    background: "#0b1020",
+    color: "#e5e7eb",
+    padding: 12,
+    borderRadius: 14,
+    overflow: "auto",
+  },
+  row: { display: "flex", gap: 10, flexWrap: "wrap", marginTop: 12 },
+  small: { fontSize: 12, opacity: 0.85, lineHeight: 1.35 },
+  cardBtn: {
+    textAlign: "left",
+    padding: 12,
+    borderRadius: 14,
+    border: "1px solid #dbeafe",
+    background: "white",
+    cursor: "pointer",
+  },
+  footer: { textAlign: "center", padding: 22, opacity: 0.6, fontSize: 12 },
+};

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import WOOPSuccessApp from "./WOOPSuccessApp";
+
+createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <WOOPSuccessApp />
+  </React.StrictMode>,
+);


### PR DESCRIPTION
### Motivation
- Provide a compact, runnable WOOP (Wish–Outcome–Obstacle–Plan) web activity tailored to a Success course so instructors and students can run the exact Character Lab protocol in-class or asynchronously.
- Preserve the psychological sequence and language (visualization pauses, internal-obstacle rule, When–Then plans) because the effect depends on that exact structure.
- Give teachers an integrated facilitator script, a mini-textbook + Notion workflow, and an exportable WOOP card to connect the exercise to course reflection and assessment. 

### Description
- Add a single-file React component `web/src/WOOPSuccessApp.jsx` implementing a step-by-step wizard (Intro → Wish → Outcome → Obstacle → Plan → Success reflection → Wrap) with visualization timers, input gating, examples loader, facilitator script toggle, WOOP summary card, print support, and Notion-ready markdown export. 
- Add a minimal Vite scaffold (`web/package.json`, `web/index.html`, `web/src/main.jsx`) so the component can be started locally with `npm`/`vite` and built for production. 
- Add pedagogy and integration docs in `docs/woop_success_course_guide.md` that explain the core science (mental contrasting, implementation intentions), map WOOP steps to course objectives, and list the Notion database schema and template guidance. 
- Update repository docs and ignore rules: update `README.md` to document the new app and original analysis script, and add `.gitignore` entries for `web/node_modules/` and `web/dist/`.

### Testing
- Ran `npm ci` inside `web/` to install dependencies and it completed successfully. 
- Ran `npm run build` inside `web/` and Vite built the production bundle successfully (dist artifacts produced). 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, loaded the app in a headless browser, and captured a full-page screenshot for visual verification (artifact produced). 
- No automated test failures were observed during install, build, or the headless render steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69930df06e008328ac0483b205aa22aa)